### PR TITLE
Shrink docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:4.2
+FROM ibmcom/swift-ubuntu:latest as builder
 
 WORKDIR /opt/OtaDeployState
 
@@ -9,6 +9,12 @@ COPY Package.resolved .
 COPY Sources ./Sources
 
 RUN swift build -c release
+
+FROM ibmcom/swift-ubuntu-runtime:latest
+
+WORKDIR /opt/OtaDeployState
+COPY --from=builder /opt/OtaDeployState/.build/release/OtaDeployState ./.build/release/OtaDeployState
+
 
 RUN mkdir -p /usr/local/opt/ota-deploy-state/
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker-run:
 		--rm \
 		-it \
 		--net=host \
-		advancedtelematic/ota-deploy-state ./.build/debug/OtaDeployState
+		advancedtelematic/ota-deploy-state
 
 docker-run-interactive:
 	docker run \


### PR DESCRIPTION
From 1.5 gigs to 280mb, which is still about x28 too big but it'll have to stay that way for a while until static binaries are an option.