### PR TITLE
Use UUID as token ID

### DIFF
--- a/Sources/Vault/Vault.swift
+++ b/Sources/Vault/Vault.swift
@@ -89,7 +89,7 @@ public final class Vault {
 
     func createAndSaveToken(token: VaultConfig.Token) -> Promise<Kube.Secret<VaultApi.TokenK8s>> {
         return Promise<Kube.Secret<VaultApi.TokenK8s>> { seal in
-            let req = VaultApi.TokenCreateRequest(period: token.period, policies: token.policies, displayName: token.displayName)
+            let req = VaultApi.TokenCreateRequest(period: token.period, policies: token.policies, displayName: token.displayName, id: UUID().uuidString)
             self.vaultApi.createToken(tokenCreateRequest: req)
                 .then({ tokenResponse -> Promise<Kube.Secret<VaultApi.TokenK8s>> in
                 self.kube.updateSecret(name: token.displayName, body: VaultApi.TokenK8s(token: tokenResponse.auth.clientToken))


### PR DESCRIPTION
This is similar to vault pre v1.0.0. After that version vault prefixed
tokens with 's.', and disallowed recreating tokens with the 's.' prefix.
To allow ota-deploy-state to function it needs to be able to
create/recreate these tokens, hence setting the value

Signed-off-by: Alex Humphreys <alex.humphreys@here.com>